### PR TITLE
Update pnpm action to latest version

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.4.0
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3


### PR DESCRIPTION
Update pnpm action to the latest version, which also brings fixes for `set-output` and `set-state` command [deprecation warnings](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/) from [2.2.4](https://github.com/pnpm/action-setup/releases/tag/v2.2.4).